### PR TITLE
Update plugin's config argument to use api_key instead of mailchimp_api_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ connection "mailchimp" {
   plugin = "mailchimp"
 
   # Authentication information
-  mailchimp_api_key = "08355689e3e6f9fd0f5630362b16b1b5-us21"
+  api_key = "08355689e3e6f9fd0f5630362b16b1b5-us21"
 }
 ```
 
 Or through environment variables:
 
 ```sh
-export MAILCHIMP_API_KEY=08355689e3e6f9fd0f5630362b16b1b5-us21
+export API_KEY=08355689e3e6f9fd0f5630362b16b1b5-us21
 ```
 
 Run steampipe:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ connection "mailchimp" {
 Or through environment variables:
 
 ```sh
-export API_KEY=08355689e3e6f9fd0f5630362b16b1b5-us21
+export MAILCHIMP_API_KEY=08355689e3e6f9fd0f5630362b16b1b5-us21
 ```
 
 Run steampipe:

--- a/config/mailchimp.spc
+++ b/config/mailchimp.spc
@@ -3,6 +3,6 @@ connection "mailchimp" {
 
   # Mailchimp API key for requests. Required.
   # Generate your API Key as per: https://mailchimp.com/developer/marketing/guides/quick-start/#generate-your-api-key/
-  # This can also be set via the MAILCHIMP_API_KEY environment variable
-  # mailchimp_api_key = "08355689e3e6f9fd0f5630362b16b1b5-us21"
+  # This can also be set via the API_KEY environment variable
+  # api_key = "08355689e3e6f9fd0f5630362b16b1b5-us21"
 }

--- a/config/mailchimp.spc
+++ b/config/mailchimp.spc
@@ -3,6 +3,6 @@ connection "mailchimp" {
 
   # Mailchimp API key for requests. Required.
   # Generate your API Key as per: https://mailchimp.com/developer/marketing/guides/quick-start/#generate-your-api-key/
-  # This can also be set via the API_KEY environment variable
+  # This can also be set via the MAILCHIMP_API_KEY environment variable
   # api_key = "08355689e3e6f9fd0f5630362b16b1b5-us21"
 }

--- a/config/mailchimp.spc
+++ b/config/mailchimp.spc
@@ -3,6 +3,6 @@ connection "mailchimp" {
 
   # Mailchimp API key for requests. Required.
   # Generate your API Key as per: https://mailchimp.com/developer/marketing/guides/quick-start/#generate-your-api-key/
-  # This can also be set via the MAILCHIMP_API_KEY environment variable
+  # This can also be set via the `MAILCHIMP_API_KEY` environment variable
   # api_key = "08355689e3e6f9fd0f5630362b16b1b5-us21"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ steampipe plugin install mailchimp
 | Credentials | Mailchimp requires an [API key](https://mailchimp.com/developer/marketing/guides/quick-start/#generate-your-api-key/) for all requests.                                                               |
 | Permissions | API keys have the same permissions as the user who creates them, and if the user permissions change, the API key permissions also change.                                                             |
 | Radius      | Each connection represents a single Mailchimp Installation.                                                                                                                                           |
-| Resolution  | 1. Credentials explicitly set in a steampipe config file (`~/.steampipe/config/mailchimp.spc`)<br />2. Credentials specified in environment variables, e.g., `MAILCHIMP_API_KEY`.                     |
+| Resolution  | 1. Credentials explicitly set in a steampipe config file (`~/.steampipe/config/mailchimp.spc`)<br />2. Credentials specified in environment variables, e.g., `API_KEY`.                     |
 
 ### Configuration
 
@@ -73,15 +73,15 @@ connection "mailchimp" {
 
   # Mailchimp API key for requests. Required.
   # Generate your API Key as per: https://mailchimp.com/developer/marketing/guides/quick-start/#generate-your-api-key/
-  # This can also be set via the `MAILCHIMP_API_KEY` environment variable.
-  # mailchimp_api_key = "08355689e3e6f9fd0f5630362b16b1b5-us21"
+  # This can also be set via the `API_KEY` environment variable.
+  # api_key = "08355689e3e6f9fd0f5630362b16b1b5-us21"
 }
 ```
 
-Alternatively, you can also use the standard Mailchimp environment variables to obtain credentials **only if other argument (`mailchimp_api_key`) is not specified** in the connection:
+Alternatively, you can also use the standard Mailchimp environment variables to obtain credentials **only if other argument (`api_key`) is not specified** in the connection:
 
 ```sh
-export MAILCHIMP_API_KEY=q8355689e3e6f9fd0f5630362b16b1b5-us21
+export API_KEY=q8355689e3e6f9fd0f5630362b16b1b5-us21
 ```
 
 ## Get involved

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ steampipe plugin install mailchimp
 | Credentials | Mailchimp requires an [API key](https://mailchimp.com/developer/marketing/guides/quick-start/#generate-your-api-key/) for all requests.                                                               |
 | Permissions | API keys have the same permissions as the user who creates them, and if the user permissions change, the API key permissions also change.                                                             |
 | Radius      | Each connection represents a single Mailchimp Installation.                                                                                                                                           |
-| Resolution  | 1. Credentials explicitly set in a steampipe config file (`~/.steampipe/config/mailchimp.spc`)<br />2. Credentials specified in environment variables, e.g., `API_KEY`.                     |
+| Resolution  | 1. Credentials explicitly set in a steampipe config file (`~/.steampipe/config/mailchimp.spc`)<br />2. Credentials specified in environment variables, e.g., `MAILCHIMP_API_KEY`.                     |
 
 ### Configuration
 
@@ -73,7 +73,7 @@ connection "mailchimp" {
 
   # Mailchimp API key for requests. Required.
   # Generate your API Key as per: https://mailchimp.com/developer/marketing/guides/quick-start/#generate-your-api-key/
-  # This can also be set via the `API_KEY` environment variable.
+  # This can also be set via the `MAILCHIMP_API_KEY` environment variable.
   # api_key = "08355689e3e6f9fd0f5630362b16b1b5-us21"
 }
 ```
@@ -81,7 +81,7 @@ connection "mailchimp" {
 Alternatively, you can also use the standard Mailchimp environment variables to obtain credentials **only if other argument (`api_key`) is not specified** in the connection:
 
 ```sh
-export API_KEY=q8355689e3e6f9fd0f5630362b16b1b5-us21
+export MAILCHIMP_API_KEY=q8355689e3e6f9fd0f5630362b16b1b5-us21
 ```
 
 ## Get involved

--- a/mailchimp/connection_config.go
+++ b/mailchimp/connection_config.go
@@ -6,11 +6,11 @@ import (
 )
 
 type mailchimpConfig struct {
-	MailchimpAPIKey *string `cty:"mailchimp_api_key"`
+	APIKey *string `cty:"api_key"`
 }
 
 var ConfigSchema = map[string]*schema.Attribute{
-	"mailchimp_api_key": {
+	"api_key": {
 		Type: schema.TypeString,
 	},
 }

--- a/mailchimp/service.go
+++ b/mailchimp/service.go
@@ -18,17 +18,17 @@ func connectMailchimp(ctx context.Context, d *plugin.QueryData) (*gochimp3.API, 
 	}
 
 	// Default to using env vars (#2)
-	apiKey := os.Getenv("MAILCHIMP_API_KEY")
+	apiKey := os.Getenv("API_KEY")
 
 	// But prefer the config (#1)
 	mailchimpConfig := GetConfig(d.Connection)
-	if mailchimpConfig.MailchimpAPIKey != nil {
-		apiKey = *mailchimpConfig.MailchimpAPIKey
+	if mailchimpConfig.APIKey != nil {
+		apiKey = *mailchimpConfig.APIKey
 	}
 
 	if apiKey == "" {
 		// Credentials not set
-		return nil, errors.New("mailchimp_api_key must be configured")
+		return nil, errors.New("api_key must be configured")
 	}
 
 	client := gochimp3.New(apiKey)

--- a/mailchimp/service.go
+++ b/mailchimp/service.go
@@ -18,7 +18,7 @@ func connectMailchimp(ctx context.Context, d *plugin.QueryData) (*gochimp3.API, 
 	}
 
 	// Default to using env vars (#2)
-	apiKey := os.Getenv("API_KEY")
+	apiKey := os.Getenv("MAILCHIMP_API_KEY")
 
 	// But prefer the config (#1)
 	mailchimpConfig := GetConfig(d.Connection)


### PR DESCRIPTION


# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
